### PR TITLE
net-fs/netdev-automount: fix closing tag in metadata.xml

### DIFF
--- a/net-fs/netdev-automount/metadata.xml
+++ b/net-fs/netdev-automount/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Xarblu</name>
 	</maintainer>
 	<use>
-		<flag name="networkmanager">Create symlinks for NetworkManager-dispatcher<flag>
+		<flag name="networkmanager">Create symlinks for NetworkManager-dispatcher</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Closes: https://bugs.gentoo.org/910683