### PR TITLE
sys-kernel/kernelscripts: update DEPENDs

### DIFF
--- a/sys-kernel/kernelscripts/kernelscripts-6.0-r2.ebuild
+++ b/sys-kernel/kernelscripts/kernelscripts-6.0-r2.ebuild
@@ -12,7 +12,7 @@ SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
-	|| ( sys-kernel/installkernel-gentoo sys-kernel/installkernel-systemd )
+	|| ( sys-kernel/installkernel sys-kernel/installkernel-systemd )
 "
 
 src_install() {


### PR DESCRIPTION
`installkernel-gentoo` and `installkernel-systemd` were combined in a single `installkernel`, `installkernel-systemd` still exists as an alternative in `::gentoo`