### PR TITLE
profiles: multilib -> force 32 bit llvm runtimes

### DIFF
--- a/profiles/default/linux/amd64/17.1/desktop/plasma/systemd/clang/package.use.force
+++ b/profiles/default/linux/amd64/17.1/desktop/plasma/systemd/clang/package.use.force
@@ -1,0 +1,13 @@
+# Copyright 2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# build 32 bit LLVM runtimes so clang -m32 works
+sys-devel/clang-runtime abi_x86_32
+sys-libs/compiler-rt abi_x86_32
+sys-libs/compiler-rt-sanitizers abi_x86_32
+sys-libs/libcxx abi_x86_32
+sys-libs/libcxxabi abi_x86_32
+sys-libs/libomp abi_x86_32
+sys-libs/libxcrypt abi_x86_32
+sys-libs/llvm-libunwind abi_x86_32
+virtual/libcrypt abi_x86_32


### PR DESCRIPTION
These are required for clang -m32 to work