### PR TITLE
games-util/mangohud: DROP IUSE doc, install unconditionally

### DIFF
--- a/games-util/mangohud/metadata.xml
+++ b/games-util/mangohud/metadata.xml
@@ -10,7 +10,6 @@
 		<bugs-to>https://github.com/flightlessmango/MangoHud/issues</bugs-to>
 	</upstream>
 	<use>
-		<flag name="doc">Include the example config, man pages, appstream files etc</flag>
 		<flag name="mangoapp">Build MangoApp for use with <pkg>gui-wm/gamescope</pkg></flag>
 		<flag name="mangohudctl">Build MangoHudCTL</flag>
 		<flag name="mangoplot">Install MangoPlot and its dependencies</flag>


### PR DESCRIPTION
Install "doc" unconditionally. All files together are < 50kB and the manpage might be useful for info on ENV vars, config paths, etc.