### PR TITLE
games-util/mangohud: relax glfw usedep

### DIFF
--- a/games-util/mangohud/mangohud-0.7.1-r3.ebuild
+++ b/games-util/mangohud/mangohud-0.7.1-r3.ebuild
@@ -75,7 +75,7 @@ DEPEND="
 	dbus? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
 	mangoapp? (
 		media-libs/glew[${MULTILIB_USEDEP}]
-		media-libs/glfw[-wayland-only,${MULTILIB_USEDEP}]
+		media-libs/glfw[wayland-only(-),X(+),${MULTILIB_USEDEP}]
 	)
 	mangoplot? (
 		$(python_gen_cond_dep '


### PR DESCRIPTION
>=media-libs/glfw-3.4 dropped USE=wayland-only
in favour of USE=X,wayland