### PR TITLE
games-util/mangohud: force bundled imgui/implot

### DIFF
--- a/games-util/mangohud/files/0.8.1-use-bundled-imgui-and-implot.patch
+++ b/games-util/mangohud/files/0.8.1-use-bundled-imgui-and-implot.patch
@@ -1,0 +1,39 @@
+From b63d61696ca394178c06ff52f30334ea6479a828 Mon Sep 17 00:00:00 2001
+From: Xarblu <xarblu@protonmail.com>
+Date: Wed, 29 Oct 2025 10:05:27 +0100
+Subject: [PATCH] use bundled imgui and implot
+
+We expect these to be used anyways but users may
+have them installed from other overlays.
+Remove the auto-magic dep detection and always use the bundled
+version.
+
+Closes: https://github.com/xarblu/xarblu-overlay/issues/787
+Signed-off-by: Xarblu <xarblu@protonmail.com>
+---
+ meson.build | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index ebe37c8..a485907 100644
+--- a/meson.build
++++ b/meson.build
+@@ -222,10 +222,13 @@ if get_option('mangoapp')
+     'glfw=enabled',
+   ]
+ endif
+-dearimgui_dep = dependency('imgui', fallback: ['imgui'], required: true, default_options: imgui_options)
++
++dearimgui_sp = subproject('imgui', default_options: imgui_options)
++dearimgui_dep = dearimgui_sp.get_variable('imgui_dep')
+ 
+ if is_unixy
+-implot_dep = dependency('implot', fallback: ['implot'], required: true, default_options: ['default_library=static'])
++implot_sp = subproject('implot', default_options: ['default_library=static'])
++implot_dep = implot_sp.get_variable('implot_dep')
+ else
+ implot_dep = null_dep
+ implot_lib = static_library('nulllib', [])
+-- 
+2.51.2
+

--- a/games-util/mangohud/mangohud-0.8.1-r1.ebuild
+++ b/games-util/mangohud/mangohud-0.8.1-r1.ebuild
@@ -1,0 +1,195 @@
+# Copyright 1999-2025 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{10..13} )
+
+inherit toolchain-funcs flag-o-matic python-r1 desktop meson-multilib
+
+DESCRIPTION="Vulkan and OpenGL overlay for monitoring FPS, sensors, system load and more"
+HOMEPAGE="https://github.com/flightlessmango/MangoHud"
+
+MY_PV=$(ver_cut 1-3)
+[[ -n "$(ver_cut 4-)" ]] && MY_PV_REV="-$(ver_cut 4-)"
+
+# required subprojects
+declare -A subprojectv=(
+	[vkheaders]="1.2.158"
+	[vkheaders_meson]="1.2.158-2"
+	[imgui]="1.89.9"
+	[imgui_meson]="1.89.9-1"
+	[implot]="0.16"
+	[implot_meson]="0.16-1"
+)
+
+SRC_URI="
+	https://github.com/flightlessmango/MangoHud/archive/v${MY_PV}${MY_PV_REV}.tar.gz -> ${P}.tar.gz
+	https://github.com/KhronosGroup/Vulkan-Headers/archive/v${subprojectv[vkheaders]}.tar.gz -> vulkan-headers-${subprojectv[vkheaders]}.tar.gz
+	https://wrapdb.mesonbuild.com/v2/vulkan-headers_${subprojectv[vkheaders_meson]}/get_patch/vulkan-headers-${subprojectv[vkheaders_meson]}-wrap.zip
+	https://github.com/ocornut/imgui/archive/v${subprojectv[imgui]}.tar.gz -> imgui-${subprojectv[imgui]}.tar.gz
+	https://wrapdb.mesonbuild.com/v2/imgui_${subprojectv[imgui_meson]}/get_patch/imgui-${subprojectv[imgui_meson]}-wrap.zip
+	https://github.com/epezent/implot/archive/v${subprojectv[implot]}.tar.gz -> imgui-${subprojectv[implot]}.tar.gz
+	https://wrapdb.mesonbuild.com/v2/implot_${subprojectv[implot_meson]}/get_patch/implot-${subprojectv[implot_meson]}-wrap.zip
+"
+
+KEYWORDS="~amd64"
+LICENSE="MIT"
+SLOT="0"
+IUSE="+dbus debug mangoapp mangoplot test wayland video_cards_nvidia +X xnvctrl"
+
+REQUIRED_USE="
+	|| ( X wayland )
+	mangoapp? ( X )
+	xnvctrl? ( video_cards_nvidia X )
+	${PYTHON_REQUIRED_USE}
+"
+
+RESTRICT="!test? ( test )"
+
+# shellcheck disable=SC2016
+BDEPEND="
+	app-arch/unzip
+	test? ( dev-util/cmocka[${MULTILIB_USEDEP}] )
+	$(python_gen_cond_dep 'dev-python/mako[${PYTHON_USEDEP}]')
+	${PYTHON_DEPS}
+"
+
+DEPEND="
+	dev-cpp/nlohmann_json
+	dev-libs/spdlog[${MULTILIB_USEDEP}]
+	dev-util/glslang[${MULTILIB_USEDEP}]
+	media-libs/libglvnd[${MULTILIB_USEDEP}]
+	media-libs/vulkan-loader[${MULTILIB_USEDEP}]
+	x11-libs/libdrm[${MULTILIB_USEDEP}]
+	dbus? ( sys-apps/dbus[${MULTILIB_USEDEP}] )
+	mangoapp? (
+		media-libs/glew[${MULTILIB_USEDEP}]
+		media-libs/glfw[-wayland-only(-),X(+),${MULTILIB_USEDEP}]
+	)
+	video_cards_nvidia? (
+		x11-drivers/nvidia-drivers[${MULTILIB_USEDEP}]
+		xnvctrl? ( x11-drivers/nvidia-drivers[static-libs] )
+	)
+	wayland? (
+		>=dev-libs/wayland-1.11[${MULTILIB_USEDEP}]
+		x11-libs/libxkbcommon[${MULTILIB_USEDEP}]
+	)
+	X? (
+		x11-libs/libX11[${MULTILIB_USEDEP}]
+		x11-libs/libxkbcommon[${MULTILIB_USEDEP}]
+	)
+	${PYTHON_DEPS}
+"
+
+# shellcheck disable=SC2016
+RDEPEND="
+	mangoplot? (
+		$(python_gen_cond_dep '
+			dev-python/numpy[${PYTHON_USEDEP}]
+			dev-python/matplotlib[${PYTHON_USEDEP}]
+		')
+	)
+	${DEPEND}
+"
+
+S="${WORKDIR}/MangoHud-${PV}"
+
+PATCHES=(
+	"${FILESDIR}/0.8.1-use-bundled-imgui-and-implot.patch"
+)
+
+python_check_deps() {
+	python_has_version -b "dev-python/mako[${PYTHON_USEDEP}]"
+}
+
+pkg_setup() {
+	python_setup
+}
+
+src_unpack() {
+	default
+	[[ -n "${MY_PV_REV}" ]] && ( mv "${WORKDIR}/MangoHud-${MY_PV}${MY_PV_REV}" "${WORKDIR}/MangoHud-${PV}" || die )
+
+	# symlink subprojects
+	local projects=(
+		"Vulkan-Headers-${subprojectv[vkheaders]}"
+		"imgui-${subprojectv[imgui]}"
+		"implot-${subprojectv[implot]}"
+	)
+
+	for subproject in "${projects[@]}"; do
+		einfo "Installing subproject ${subproject}"
+		mv -vt "${S}/subprojects/" "${WORKDIR}/${subproject}" || die "Couldn't install ${subproject}"
+	done
+}
+
+src_prepare() {
+	# set version since we don't have git tags
+	sed -i -e "/^project('MangoHud',$/,/^)$/s/version : '.*'/version : '${MY_PV}${MY_PV_REV}'/" \
+		meson.build || die
+
+	# mangohud by default statically links libstdc++
+	# dynamically linked libc++ works just fine though
+	if [[ "$(tc-get-cxx-stdlib)" == "libc++" ]]; then
+		eapply "${FILESDIR}/0.8.0_rc1-libcxx.patch"
+	fi
+
+	# https://github.com/flightlessmango/MangoHud/issues/1240
+	# lld throws an error, mold just a warning, bfd doesn't care
+	if [[ "$(tc-getLD)" == "ld.lld" ]]; then
+		append-ldflags "-Wl,--undefined-version"
+	fi
+
+	default
+}
+
+# shellcheck disable=SC2207
+multilib_src_configure() {
+	local emesonargs=(
+		-Duse_system_spdlog=enabled
+		-Dappend_libdir_mangohud=false
+		# QA: install docs in src_install to ensure FHS/Gentoo policy
+		# also avoids dev-libs/appstream test dep
+		-Dinclude_doc=false
+		$(meson_feature video_cards_nvidia with_nvml)
+		$(meson_feature xnvctrl with_xnvctrl)
+		$(meson_feature X with_x11)
+		$(meson_feature wayland with_wayland)
+		$(meson_feature dbus with_dbus)
+		$(meson_use mangoapp mangoapp)
+		# mangohudctl only makes sense with mangoapp
+		$(meson_use mangoapp mangohudctl)
+		$(meson_feature test tests)
+		$(meson_feature mangoplot mangoplot)
+		-Ddynamic_string_tokens=true
+		# no extra deps and just a single object so whatever
+		-Dwith_fex=true
+	)
+	meson_src_configure
+}
+
+multilib_src_install_all() {
+	# extra stuff under data/ (usually controlled by -Dinclude_doc)
+	insinto /usr/share/metainfo
+	doins data/io.github.flightlessmango.mangohud.metainfo.xml
+	doicon -s scalable data/io.github.flightlessmango.mangohud.svg
+	doman data/mangohud.1
+	use mangoapp && doman data/mangoapp.1
+	newdoc data/MangoHud.conf MangoHud.conf.example
+	newdoc data/presets.conf presets.conf.example
+}
+
+pkg_postinst() {
+	if ! use xnvctrl; then
+		elog ""
+		elog "If mangohud can't get GPU load, or other GPU information,"
+		elog "and you may have an older Nvidia device."
+		elog ""
+		elog "Try enabling the 'xnvctrl' useflag."
+		elog ""
+	fi
+}


### PR DESCRIPTION
I don't package the system versions here and thus they're untested and unsupported.
Remove the automagic to force use of the bundled versions.

Fixes: https://github.com/xarblu/xarblu-overlay/issues/787